### PR TITLE
LoginControllerTest - Tests Passed

### DIFF
--- a/src/main/java/com/matamercer/microblog/security/UserPrincipal.kt
+++ b/src/main/java/com/matamercer/microblog/security/UserPrincipal.kt
@@ -7,7 +7,7 @@ import org.springframework.security.core.authority.SimpleGrantedAuthority
 import org.springframework.security.core.userdetails.UserDetails
 
 class UserPrincipal(
-    private var id: Long,
+    var id: Long,
     private var username: String = "",
     private var password: String? = null,
     private var isAccountNonExpired: Boolean = true,

--- a/src/main/java/com/matamercer/microblog/security/authentication/JwtConfig.kt
+++ b/src/main/java/com/matamercer/microblog/security/authentication/JwtConfig.kt
@@ -8,7 +8,7 @@ import org.springframework.stereotype.Component
 @ConfigurationProperties(prefix = "application.jwt")
 class JwtConfig {
     var secretKey: String? = null
-    var tokenPrefix: String? = null
+    var tokenPrefix: String = "Bearer"
     var refreshTokenExpirationInDays: Int = 0
     var accessTokenExpirationInHours: Int = 0
     val authorizationHeader: String

--- a/src/main/java/com/matamercer/microblog/security/authentication/JwtTokenVerifier.kt
+++ b/src/main/java/com/matamercer/microblog/security/authentication/JwtTokenVerifier.kt
@@ -1,13 +1,12 @@
 package com.matamercer.microblog.security.authentication
 
-import com.google.common.base.Strings
 import com.matamercer.microblog.models.entities.Blog
 import com.matamercer.microblog.security.UserPrincipal
 import com.matamercer.microblog.security.authorization.UserRole
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
-import org.springframework.security.core.Authentication
 import org.springframework.security.core.AuthenticationException
 import org.springframework.security.core.context.SecurityContextHolder
+import org.springframework.security.web.authentication.WebAuthenticationDetailsSource
 import org.springframework.web.filter.OncePerRequestFilter
 import java.io.IOException
 import javax.crypto.SecretKey
@@ -28,14 +27,14 @@ class JwtTokenVerifier(
         filterChain: FilterChain
     ) {
         val authorizationHeader = request.getHeader(jwtConfig.authorizationHeader)
-        if (Strings.isNullOrEmpty(authorizationHeader) || !authorizationHeader!!.startsWith(
-                jwtConfig.tokenPrefix!!
+        if (authorizationHeader.isEmpty() || !authorizationHeader.startsWith(
+                "Bearer"
             )
         ) {
             filterChain.doFilter(request, response)
             return
         }
-        val token = authorizationHeader.replace(jwtConfig.tokenPrefix!!, "")
+        val token = authorizationHeader.replace("Bearer", "")
         try {
             val body = jwtUtil.extractAllClaims(token)
             val userId = body["userId"].toString().toLong()
@@ -48,18 +47,21 @@ class JwtTokenVerifier(
 
             val activeBlog = Blog()
             activeBlog.id = activeBlogId
-            val userPrincipal= UserPrincipal(
+            val userPrincipal = UserPrincipal(
                 id = userId,
-                username=username,
+                username = username,
                 activeBlog = activeBlog,
-                role = userRole )
+                role = userRole
+            )
 
-            val authentication: Authentication = UsernamePasswordAuthenticationToken(
+            val authentication = UsernamePasswordAuthenticationToken(
                 userPrincipal,
                 null,
                 simpleGrantedAuthorities
             )
+            authentication.details = WebAuthenticationDetailsSource().buildDetails(request)
             SecurityContextHolder.getContext().authentication = authentication
+            println(authentication.details)
         } catch (e: AuthenticationException) {
             request.setAttribute("exception", e)
         }

--- a/src/main/java/com/matamercer/microblog/security/authentication/JwtTokenVerifier.kt
+++ b/src/main/java/com/matamercer/microblog/security/authentication/JwtTokenVerifier.kt
@@ -59,9 +59,7 @@ class JwtTokenVerifier(
                 null,
                 simpleGrantedAuthorities
             )
-            authentication.details = WebAuthenticationDetailsSource().buildDetails(request)
             SecurityContextHolder.getContext().authentication = authentication
-            println(authentication.details)
         } catch (e: AuthenticationException) {
             request.setAttribute("exception", e)
         }

--- a/src/main/java/com/matamercer/microblog/security/authentication/JwtUtil.kt
+++ b/src/main/java/com/matamercer/microblog/security/authentication/JwtUtil.kt
@@ -73,7 +73,7 @@ class JwtUtil @Autowired constructor(
         val refreshTokenEntity = refreshTokenRepository.save(RefreshToken(user))
         val claims = getUserClaims(user.id, user.username, user.role, user.activeBlog?.id)
         claims["refreshTokenEntityId"] = refreshTokenEntity.id.toString()
-        return createToken(
+        return "Bearer" + createToken(
             claims,
             Date.valueOf(LocalDate.now().plusDays(jwtConfig.refreshTokenExpirationInDays.toLong()))
         )

--- a/src/main/java/com/matamercer/microblog/security/authentication/JwtUtil.kt
+++ b/src/main/java/com/matamercer/microblog/security/authentication/JwtUtil.kt
@@ -39,7 +39,7 @@ class JwtUtil @Autowired constructor(
         val user = optionalUser.orElseThrow {
             throw UserNotFoundException("Error creating access token. User not found.")
         }
-        return createToken(
+        return "Bearer"+ createToken(
             getUserClaims(user.id, user.username, user.role, user.activeBlog?.id),
             addHoursToCurrentDate(jwtConfig.accessTokenExpirationInHours)
         )

--- a/src/main/java/com/matamercer/microblog/web/api/v1/UserRestController.kt
+++ b/src/main/java/com/matamercer/microblog/web/api/v1/UserRestController.kt
@@ -1,7 +1,7 @@
 package com.matamercer.microblog.web.api.v1
 
-import com.matamercer.microblog.models.entities.User
 import com.matamercer.microblog.security.CurrentUser
+import com.matamercer.microblog.security.UserPrincipal
 import com.matamercer.microblog.services.UserService
 import com.matamercer.microblog.web.api.v1.dto.responses.UserResponseDto
 import org.springframework.beans.factory.annotation.Autowired
@@ -14,8 +14,8 @@ import org.springframework.web.bind.annotation.RestController
 @RequestMapping("/api/v1/user")
 class UserRestController @Autowired constructor(private val userService: UserService) {
     @GetMapping("/currentuser")
-    fun currentUser(@CurrentUser userPrincipal: User): ResponseEntity<UserResponseDto?> {
-        val user = userService.getUser(userPrincipal.id!!)
+    fun currentUser(@CurrentUser userPrincipal: UserPrincipal): ResponseEntity<UserResponseDto?> {
+        val user = userService.getUser(userPrincipal.id)
         return ResponseEntity.ok(user)
     }
 }

--- a/src/test/java/com/matamercer/microblog/integration/controller/LoginControllerTest.kt
+++ b/src/test/java/com/matamercer/microblog/integration/controller/LoginControllerTest.kt
@@ -1,70 +1,86 @@
 package com.matamercer.microblog.integration.controller
 
 import com.matamercer.microblog.models.entities.AuthenticationProvider
+import com.matamercer.microblog.models.entities.Blog
 import com.matamercer.microblog.models.entities.User
+import com.matamercer.microblog.models.repositories.BlogRepository
+import com.matamercer.microblog.models.repositories.RefreshTokenRepository
 import com.matamercer.microblog.models.repositories.UserRepository
 import com.matamercer.microblog.security.authentication.JwtConfig
-import com.matamercer.microblog.security.authentication.JwtUtil
 import com.matamercer.microblog.security.authorization.UserRole
 import com.matamercer.microblog.services.UserService
 import com.matamercer.microblog.utilities.EnvironmentUtil
 import com.matamercer.microblog.web.api.v1.dto.requests.LoginUserRequestDto
+import io.mockk.clearAllMocks
 import io.mockk.junit5.MockKExtension
-import org.assertj.core.api.Assertions
-import org.junit.jupiter.api.AfterEach
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
+import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.boot.test.web.client.TestRestTemplate
-import org.springframework.http.HttpHeaders
-import org.springframework.http.HttpStatus
-import org.springframework.http.MediaType
-import org.springframework.http.RequestEntity
+import org.springframework.http.*
 import org.springframework.security.crypto.password.PasswordEncoder
 import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.context.junit.jupiter.SpringExtension
 import java.net.URI
 import java.net.UnknownHostException
 
-@ExtendWith(MockKExtension::class)
+@ExtendWith(MockKExtension::class, SpringExtension::class)
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @ActiveProfiles("test")
-class LoginControllerTest(
-    private val userRepository: UserRepository?,
-    private val passwordEncoder: PasswordEncoder?,
-    private val userService: UserService?,
-    private val environmentUtil: EnvironmentUtil?,
-    private val jwtUtil: JwtUtil,
-    private val jwtConfig: JwtConfig?,
+class LoginControllerTest @Autowired constructor(
+    private val userService: UserService,
+    private val passwordEncoder: PasswordEncoder,
+    private val jwtConfig: JwtConfig,
+    private val environmentUtil: EnvironmentUtil,
+    private val userRepository: UserRepository,
+    private val refreshTokenRepository: RefreshTokenRepository,
+    private val blogRepository: BlogRepository
 ) {
-
     private var testRestTemplate: TestRestTemplate? = null
-    private var user: User? = null
+
+    private lateinit var user: User
+
+    private lateinit var responseEntity: ResponseEntity<Any>
+
+    private lateinit var requestEntity: RequestEntity<LoginUserRequestDto>
+
     private var unencodedPassword: String? = null
 
     @BeforeEach
     fun initData() {
+        clearAllMocks()
+        userRepository.deleteAll()
+        refreshTokenRepository.deleteAll()
+        blogRepository.deleteAll()
         unencodedPassword = "password"
         user = User(
             "username@gmail.com",
             "username",
-            passwordEncoder!!.encode(unencodedPassword),
+            passwordEncoder.encode(unencodedPassword),
             UserRole.BLOGGER,
             AuthenticationProvider.LOCAL
         )
-        user = userService!!.createUser(user!!)
+        val blog = Blog(isSensitive = true, preferredBlogName = "Testermourne", blogName = "Tester Agony")
+        blogRepository.save(blog)
+        user.activeBlog = blog
+        user = userService.createUser(user)
         testRestTemplate = TestRestTemplate()
-    }
-
-    @AfterEach
-    fun disposeData() {
-        userRepository!!.deleteById(user!!.id)
+        requestEntity = getLoginRequestEntity(
+            LoginUserRequestDto(
+                user.username!!,
+                unencodedPassword!!
+            )
+        )
+        responseEntity = testRestTemplate!!.exchange(requestEntity, Any::class.java)
     }
 
     @Throws(UnknownHostException::class)
     private fun getLoginRequestEntity(loginUserRequestDTO: LoginUserRequestDto): RequestEntity<LoginUserRequestDto> {
         return RequestEntity
-            .post(URI.create(environmentUtil!!.serverUrl + "/api/v1/auth/login"))
+            .post(URI.create(environmentUtil.serverUrl + "/api/v1/auth/login"))
             .contentType(MediaType.APPLICATION_JSON)
             .body(loginUserRequestDTO)
     }
@@ -72,8 +88,8 @@ class LoginControllerTest(
     @Throws(UnknownHostException::class)
     private fun getCurrentUserRequestEntity(accessToken: String): RequestEntity<Void> {
         val headers = HttpHeaders()
-        headers.add(jwtConfig!!.authorizationHeader, accessToken)
-        return RequestEntity.get(URI.create(environmentUtil!!.serverUrl + "/api/v1/user/currentuser"))
+        headers.add(jwtConfig.authorizationHeader, accessToken)
+        return RequestEntity.get(URI.create(environmentUtil.serverUrl + "/api/v1/user/currentuser"))
             .headers(headers)
             .build()
     }
@@ -81,55 +97,35 @@ class LoginControllerTest(
     @Test
     @Throws(UnknownHostException::class)
     fun whenLogin_withGoodCredentials_thenReturnResponseIsOk_WithAccessAndRefreshTokens() {
-        val requestEntity = getLoginRequestEntity(
-            LoginUserRequestDto(
-                user!!.username!!,
-                unencodedPassword!!
-            )
-        )
-        val responseEntity = testRestTemplate!!.exchange(requestEntity, Any::class.java)
-        Assertions.assertThat(responseEntity.statusCode).isEqualTo(HttpStatus.OK)
-        val accessToken = responseEntity.headers[jwtConfig!!.authorizationHeader]!!
-            .stream().findFirst()
-        Assertions.assertThat(accessToken.isPresent).isTrue
-        val refreshToken = responseEntity.headers[jwtConfig.refreshTokenHeader]!!
-            .stream().findFirst()
-        Assertions.assertThat(refreshToken.isPresent).isTrue
+        assertThat(responseEntity.statusCode).isEqualTo(HttpStatus.OK)
+        val accessToken = responseEntity.headers[jwtConfig.authorizationHeader]!!.first()
+        assertThat(accessToken != null).isTrue
+        val refreshToken = responseEntity.headers[jwtConfig.refreshTokenHeader]!!.first()
+        assertThat(refreshToken != null).isTrue
     }
 
     @Test
     @Throws(UnknownHostException::class)
     fun whenGetCurrentUser_withAccessToken_thenReturnCurrentUser() {
-        val requestEntity = getLoginRequestEntity(
-            LoginUserRequestDto(
-                user!!.username!!,
-                unencodedPassword!!
-            )
-        )
-        val responseEntity = testRestTemplate!!.exchange(requestEntity, Any::class.java)
-        Assertions.assertThat(responseEntity.statusCode).isEqualTo(HttpStatus.OK)
-        val accessToken = responseEntity.headers[jwtConfig!!.authorizationHeader]!!
-            .stream().findFirst()
-        Assertions.assertThat(accessToken.isPresent).isTrue
-        val refreshToken = responseEntity.headers[jwtConfig.refreshTokenHeader]!!
-            .stream().findFirst()
-        Assertions.assertThat(refreshToken.isPresent).isTrue
-        val currentUserRequestEntity = getCurrentUserRequestEntity(accessToken.get())
-        val currentUserResponseEntity = testRestTemplate!!.exchange(
+        val accessToken = responseEntity.headers[jwtConfig.authorizationHeader]!!.first()
+        assertThat(accessToken != null).isTrue
+        val refreshToken = responseEntity.headers[jwtConfig.refreshTokenHeader]!!.first()
+        assertThat(refreshToken != null).isTrue
+        val currentUserRequestEntity = getCurrentUserRequestEntity(accessToken)
+        val currentUserWithTokenResponseEntity = testRestTemplate!!.exchange(
             currentUserRequestEntity,
             String::class.java
         )
-        Assertions.assertThat(currentUserResponseEntity.statusCode).isEqualTo(HttpStatus.OK)
+        assertThat(currentUserWithTokenResponseEntity.statusCode).isEqualTo(HttpStatus.OK)
     }
 
     @Test
     @Throws(UnknownHostException::class)
     fun whenGetCurrentUser_withoutAccessToken_thenReturnCurrentUser() {
-        val currentUserRequestEntity = getCurrentUserRequestEntity("")
-        val currentUserResponseEntity = testRestTemplate!!.exchange(
-            currentUserRequestEntity,
+        val currentUserWithOutTokenResponseEntity = testRestTemplate!!.exchange(
+            getCurrentUserRequestEntity(""),
             String::class.java
         )
-        Assertions.assertThat(currentUserResponseEntity.statusCode).isEqualTo(HttpStatus.FORBIDDEN)
+        assertThat(currentUserWithOutTokenResponseEntity.statusCode).isEqualTo(HttpStatus.FORBIDDEN)
     }
 }

--- a/src/test/java/com/matamercer/microblog/unit/jwt/JwtUtilTest.kt
+++ b/src/test/java/com/matamercer/microblog/unit/jwt/JwtUtilTest.kt
@@ -91,8 +91,9 @@ class JwtUtilTest {
 
     @Test
     fun whenCreateRefreshToken_returnValidRefreshToken() {
-        val token = jwtUtil.createRefreshToken(user.id!!)
-        val claims = jwtUtil.extractAllClaims(token)
+        var rToken = jwtUtil.createRefreshToken(user.id!!)
+        rToken = rToken.substring(6)
+        val claims = jwtUtil.extractAllClaims(rToken)
         assertThat(jwtUtil.isTokenExpired(claims)).isFalse
         assertThat(jwtUtil.getUserId(claims)).isEqualTo(user.id)
         assertThat(jwtUtil.getUserName(claims)).isEqualTo(user.username)

--- a/src/test/java/com/matamercer/microblog/unit/jwt/JwtUtilTest.kt
+++ b/src/test/java/com/matamercer/microblog/unit/jwt/JwtUtilTest.kt
@@ -79,7 +79,8 @@ class JwtUtilTest {
 
     @Test
     fun whenCreateAccessToken_returnValidAccessToken() {
-        val token = jwtUtil.createAccessToken(user.id!!)
+        var token = jwtUtil.createAccessToken(user.id!!)
+        token = token.substring(6)
         val claims = jwtUtil.extractAllClaims(token)
         assertThat(jwtUtil.getUserId(claims)).isEqualTo(user.id)
         assertThat(jwtUtil.getUserName(claims)).isEqualTo(user.username)
@@ -91,9 +92,9 @@ class JwtUtilTest {
 
     @Test
     fun whenCreateRefreshToken_returnValidRefreshToken() {
-        var rToken = jwtUtil.createRefreshToken(user.id!!)
-        rToken = rToken.substring(6)
-        val claims = jwtUtil.extractAllClaims(rToken)
+        var token = jwtUtil.createRefreshToken(user.id!!)
+        token = token.substring(6)
+        val claims = jwtUtil.extractAllClaims(token)
         assertThat(jwtUtil.isTokenExpired(claims)).isFalse
         assertThat(jwtUtil.getUserId(claims)).isEqualTo(user.id)
         assertThat(jwtUtil.getUserName(claims)).isEqualTo(user.username)


### PR DESCRIPTION
First Round of Integration Tests passed. 
"Bearer" prefix was brought back to  **JwtUtil**  `fun createAccessTokenHelper`.
"Bearer" was hardcoded on **JwtTokenVerifier** `doFilterInternal` 
"Bearer" was used as default on **JwtConfig** `tokenPrefix`
`id `field was made public in **UserPrincipal**
`userPrincipal` type was changed to **UserPrincipal**